### PR TITLE
Order capture form

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,8 +1,8 @@
 class OrdersController < ApplicationController
   include CurrentCart
-  before_action :set_order, only: [:show, :edit, :update, :destroy]
-  before_action :ensure_cart_isnt_empty, only: :new
   before_action :set_cart, only: [:new, :create]
+  before_action :ensure_cart_isnt_empty, only: :new
+  before_action :set_order, only: [:show, :edit, :update, :destroy]
 
   # GET /orders
   # GET /orders.json

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -70,7 +70,7 @@ class OrdersController < ApplicationController
       @order = Order.find(params[:id])
     end
 
-    # Make sure cart isn't empty before creating a new order
+    # Make sure cart isn't empty before creating a new order; prevents creating empty orders
     def ensure_cart_isnt_empty
       if @cart.line_items.empty?
         redirect_to store_index_url, notice: 'Your cart is empty'

--- a/test/controllers/orders_controller_test.rb
+++ b/test/controllers/orders_controller_test.rb
@@ -18,7 +18,7 @@ class OrdersControllerTest < ActionDispatch::IntegrationTest
 
   test "should get new" do
     #create line item so that cart isn't empty
-    post line_items_url, params: {product_id: products(:ruby).id}
+    post line_items_url, params: { product_id: products(:ruby).id }
 
     get new_order_url
     assert_response :success


### PR DESCRIPTION
Change ordering of before_action - ensuring cart wasn't empty was happening AFTER setting the order